### PR TITLE
Better memory layout, more vectorization, Numba

### DIFF
--- a/poly_match_v1_6_excessively_vectorized.py
+++ b/poly_match_v1_6_excessively_vectorized.py
@@ -1,0 +1,126 @@
+import numpy as np
+import scipy.spatial
+import matplotlib.pyplot as plt
+from matplotlib import patches
+
+def split_polygons(polygons, num_vertices):
+    # Split densely packed polygons into individual polygons.
+    # This function should not be used if performance is important.
+    i = 0
+    for n in num_vertices:
+        yield polygons[i:i+n]
+        i += n
+
+def make_polygons(n=1000, min_vertices=5, max_vertices=15, min_radius=0.5, max_radius=1.5):
+    rng = np.random.default_rng(0)
+
+    # Number of vertices of each polygon
+    num_vertices = rng.integers(min_vertices, max_vertices + 1, n)
+
+    # Compute angle for each vertex of polygon
+    poly_index = np.repeat(np.arange(n), num_vertices)
+    c = cumsum0(num_vertices)
+    ranges = np.arange(num_vertices.sum()) - c[poly_index]
+    angles = 2 * np.pi * ranges / np.repeat(num_vertices, num_vertices)
+
+    # Distance from center to vertex of polygon
+    distance = rng.uniform(min_radius, max_radius, len(angles))
+
+    # Centers of polygons (not "real" center)
+    centers = rng.uniform(0.0, 100.0, (n, 2))
+
+    # Vertex coordinates of polygons
+    x = distance * np.cos(angles) + np.repeat(centers[:, 0], num_vertices)
+    y = distance * np.sin(angles) + np.repeat(centers[:, 1], num_vertices)
+
+    polygons = np.column_stack([x, y])
+
+    return polygons, num_vertices
+
+def cumsum0(values, axis=0):
+    # np.cumsum for array prepended with zero
+    shape = list(values.shape)
+    shape[axis] = 1
+    zeros = np.zeros(shape, dtype=values.dtype)
+    return np.cumsum(np.concatenate([zeros, values], axis=axis), axis)
+
+def gather_sum(values, lengths, axis=0):
+    # Sum over consecutive value ranges of given length
+    return np.diff(cumsum0(values, axis)[cumsum0(lengths, axis)], axis=axis)
+
+def roll1(values, lengths):
+    # Roll one value back to front for given value ranges
+    indices = cumsum0(lengths)
+    extended = np.insert(values, indices[:-1], values[indices[1:] - 1])
+    del_indices = indices[1:] + np.arange(len(lengths))
+    return np.delete(extended, del_indices)
+
+def polygon_areas(polygons, num_vertices):
+    # https://en.wikipedia.org/wiki/Shoelace_formula
+    bx, by = polygons.T
+    ax = roll1(bx, num_vertices)
+    ay = roll1(by, num_vertices)
+    return 0.5 * gather_sum(ax * by - ay * bx, num_vertices)
+
+def smallest_polygon_in_range(polygons, num_vertices, points, max_dist):
+    # For each point, find the polygon with smallest area within max_dist.
+    # If no polygon is found, no point is returned.
+    centers = gather_sum(polygons, num_vertices, axis=0) / num_vertices[:, None]
+    areas = polygon_areas(polygons, num_vertices)
+
+    areas2d = np.tile(areas, (len(points), 1))
+
+    out_of_range = scipy.spatial.distance.cdist(points, centers) > max_dist
+    areas2d[out_of_range] = np.inf
+
+    polygon_indices = np.argmin(areas2d, axis=1)
+
+    # Discard points where no polygon is within range
+    valid = ~np.all(out_of_range, axis=1)
+    return points[valid], polygon_indices[valid]
+
+def draw():
+    polygons, num_vertices = make_polygons()
+
+    points = np.random.default_rng(0).uniform(0.0, 100.0, size=(100, 2))
+
+    max_dist = 10.0
+
+    valid_points, indices = smallest_polygon_in_range(polygons, num_vertices, points, max_dist)
+
+    centers = gather_sum(polygons, num_vertices, axis=0) / num_vertices[:, None]
+
+    angles = np.linspace(0, 2 * np.pi, 30)
+    cx = max_dist * np.cos(angles)
+    cy = max_dist * np.sin(angles)
+
+    plt.figure(figsize=(10, 10))
+
+    plt.scatter(*centers.T, color="cornflowerblue", s=5)
+    plt.scatter(*points.T, color="red", zorder=3)
+
+    for p, q in zip(valid_points, centers[indices]):
+        plt.plot([p[0], q[0]], [p[1], q[1]], color="green")
+        plt.plot(cx + p[0], cy + p[1], color="orange", alpha=0.2)
+
+    for polygon in split_polygons(polygons, num_vertices):
+        plt.gca().add_patch(patches.Polygon(polygon, facecolor="cornflowerblue", edgecolor="k", alpha=0.5))
+
+    plt.tight_layout()
+    plt.axis("off")
+    plt.tight_layout()
+    plt.savefig("polygons.png", dpi=150, bbox_inches="tight", pad_inches=0)
+    plt.show()
+
+def generate_example():
+    points = np.random.default_rng(0).uniform(0.0, 100.0, size=(100, 2))
+
+    return make_polygons(), points
+
+def main(polygons_num_vertices, points):
+    polygons, num_vertices = polygons_num_vertices
+
+    smallest_polygon_in_range(polygons, num_vertices, points, max_dist=10.0)
+
+if __name__ == "__main__":
+    draw()

--- a/poly_match_v1_7_numba.py
+++ b/poly_match_v1_7_numba.py
@@ -1,0 +1,79 @@
+import numpy as np
+from poly_match_v1_6_excessively_vectorized import generate_example
+import poly_match_v1_6_excessively_vectorized
+from numba import njit
+
+@njit("Tuple((f8[:, :], i8[:]))(f8[:, :], i8[:], f8[:, :], f8)", cache=True)
+def smallest_polygon_in_range(polygons, num_vertices, points, max_dist):
+    num_polys = len(num_vertices)
+    areas = np.zeros(num_polys)
+    i = 0
+    for i_poly in range(num_polys):
+        n = num_vertices[i_poly]
+        area = 0.0
+        ax = polygons[i + n - 1, 0]
+        ay = polygons[i + n - 1, 1]
+        for k in range(n):
+            bx = polygons[i + k, 0]
+            by = polygons[i + k, 1]
+            area += ax * by - ay * bx
+            ax = bx
+            ay = by
+        i += n
+        areas[i_poly] = 0.5 * area
+
+    polygon_indices = np.zeros(len(points), dtype=np.int64)
+
+    for i_point in range(len(points)):
+        x = points[i_point, 0]
+        y = points[i_point, 1]
+
+        smallest_poly = -1
+        min_area = np.inf
+
+        i = 0
+        for i_poly in range(num_polys):
+            n = num_vertices[i_poly]
+
+            in_range = False
+            for k in range(n):
+                dx = polygons[i + k, 0] - x
+                dy = polygons[i + k, 1] - y
+                if dx * dx + dy * dy <= max_dist * max_dist:
+                    in_range = True
+                    break
+
+            i += n
+
+            if in_range and areas[i_poly] < min_area:
+                min_area = areas[i_poly]
+                smallest_poly = i_poly
+
+        polygon_indices[i_point] = smallest_poly
+
+    valid = polygon_indices != -1
+    return points[valid], polygon_indices[valid]
+
+def test():
+    (polygons, num_vertices), points =  generate_example()
+
+    max_dist = 10.0
+
+    for _ in range(5):
+        from time import perf_counter
+        t = perf_counter()
+        valid_points, indices = smallest_polygon_in_range(polygons, num_vertices, points, max_dist)
+        print(perf_counter() - t)
+
+        valid_points2, indices2 = poly_match_v1_6_excessively_vectorized.smallest_polygon_in_range(polygons, num_vertices, points, max_dist)
+
+        assert np.allclose(indices, indices2)
+        assert np.allclose(valid_points, valid_points2)
+
+def main(polygons_num_vertices, points):
+    polygons, num_vertices = polygons_num_vertices
+
+    smallest_polygon_in_range(polygons, num_vertices, points, max_dist=10.0)
+
+if __name__ == "__main__":
+    test()

--- a/poly_match_v1_8_numba_early_exit.py
+++ b/poly_match_v1_8_numba_early_exit.py
@@ -1,0 +1,102 @@
+import numpy as np
+from poly_match_v1_6_excessively_vectorized import generate_example
+import poly_match_v1_6_excessively_vectorized
+from numba import njit
+
+@njit("Tuple((f8[:, :], i8[:]))(f8[:, :], i8[:], f8[:, :], f8)", cache=True)
+def smallest_polygon_in_range(polygons, num_vertices, points, max_dist):
+    num_polys = len(num_vertices)
+    areas = np.zeros(num_polys)
+    centers = np.zeros((num_polys, 2))
+    radius = np.zeros(num_polys)
+
+    i = 0
+    for i_poly in range(num_polys):
+        n = num_vertices[i_poly]
+        cx = 0.0
+        cy = 0.0
+        area = 0.0
+        ax = polygons[i + n - 1, 0]
+        ay = polygons[i + n - 1, 1]
+        for k in range(n):
+            bx = polygons[i + k, 0]
+            by = polygons[i + k, 1]
+            area += ax * by - ay * bx
+            ax = bx
+            ay = by
+            cx += bx
+            cy += by
+        cx /= n
+        cy /= n
+        d = 0.0
+        for k in range(n):
+            dx = polygons[i, 0] - cx
+            dy = polygons[i, 1] - cy
+            d = max(d, np.hypot(dx, dy))
+        i += n
+        centers[i_poly, 0] = cx
+        centers[i_poly, 1] = cy
+        radius[i_poly] = np.sqrt(d)
+        areas[i_poly] = 0.5 * area
+
+    polygon_indices = np.zeros(len(points), dtype=np.int64)
+
+    for i_point in range(len(points)):
+        x = points[i_point, 0]
+        y = points[i_point, 1]
+
+        smallest_poly = -1
+        min_area = np.inf
+
+        i = 0
+        for i_poly in range(num_polys):
+            n = num_vertices[i_poly]
+            dx = x - centers[i_poly, 0]
+            dy = y - centers[i_poly, 1]
+
+            if np.sqrt(dx * dx + dy * dy) > max_dist + radius[i_poly]:
+                i += n
+                continue
+
+            in_range = False
+            for k in range(n):
+                dx = polygons[i + k, 0] - x
+                dy = polygons[i + k, 1] - y
+                if dx * dx + dy * dy <= max_dist * max_dist:
+                    in_range = True
+                    break
+
+            i += n
+
+            if in_range and areas[i_poly] < min_area:
+                min_area = areas[i_poly]
+                smallest_poly = i_poly
+
+        polygon_indices[i_point] = smallest_poly
+
+    valid = polygon_indices != -1
+    return points[valid], polygon_indices[valid]
+
+def test():
+    (polygons, num_vertices), points =  generate_example()
+
+    max_dist = 10.0
+
+    for _ in range(5):
+        from time import perf_counter
+        t = perf_counter()
+        valid_points, indices = smallest_polygon_in_range(polygons, num_vertices, points, max_dist)
+        print(perf_counter() - t)
+
+        valid_points2, indices2 = poly_match_v1_6_excessively_vectorized.smallest_polygon_in_range(polygons, num_vertices, points, max_dist)
+
+        assert np.allclose(indices, indices2)
+        assert np.allclose(valid_points, valid_points2)
+
+def main(polygons_num_vertices, points):
+    polygons, num_vertices = polygons_num_vertices
+
+    smallest_polygon_in_range(polygons, num_vertices, points, max_dist=10.0)
+
+if __name__ == "__main__":
+    test()

--- a/poly_match_v5_1_varied_polygons.py
+++ b/poly_match_v5_1_varied_polygons.py
@@ -1,0 +1,58 @@
+from typing import List, Tuple
+import numpy as np
+import poly_match_rs
+from poly_match_v1_6_excessively_vectorized import make_polygons, split_polygons
+
+
+poly_match_rs = poly_match_rs.v4
+
+Point = np.array
+
+
+class Polygon(poly_match_rs.Polygon):
+    _area: float = None
+
+    def area(self) -> float:
+        if self._area is None:
+            self._area = 0.5 * np.abs(
+                np.dot(self.x, np.roll(self.y, 1)) - np.dot(self.y, np.roll(self.x, 1))
+            )
+        return self._area
+
+def generate_example() -> Tuple[List[Polygon], List[np.array]]:
+    points = np.random.default_rng(0).uniform(0.0, 100.0, size=(100, 2))
+
+    polygons = [Polygon(*polygon.T)
+        for polygon in split_polygons(*make_polygons())]
+
+    return polygons, points
+
+
+def select_best_polygon(
+    polygon_sets: List[Tuple[Point, List[Polygon]]]
+) -> List[Tuple[Point, Polygon]]:
+    best_polygons = []
+    for point, polygons in polygon_sets:
+        best_polygon = polygons[0]
+
+        for poly in polygons:
+            if poly.area() < best_polygon.area():
+                best_polygon = poly
+
+        best_polygons.append((point, best_polygon))
+
+    return best_polygons
+
+
+def main(polygons: List[Polygon], points: np.ndarray) -> List[Tuple[Point, Polygon]]:
+    max_dist = 10.0
+    polygon_sets = poly_match_rs.find_all_close_polygons(polygons, points, max_dist)
+
+    best_polygons = select_best_polygon(polygon_sets)
+
+    return best_polygons
+
+
+if __name__ == "__main__":
+    polygons, points = generate_example()
+    main(polygons, points)


### PR DESCRIPTION
I made a few additional experiments:

- I stored the polygon vertices sequentially in memory, which allows for full vectorization with NumPy. This made things faster, but still slower than Rust.
- I tested JIT compilation with [Numba](https://numba.pydata.org/). This was faster faster than the Rust implementation.
- I again tested Numba, but this time I discarded polygons early if the center was so far away that no vertex can possibly be within range of the query point. This was much faster.

I'd also like to mention the [KDTree data structure](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.KDTree.html) which supports ball point queries. This only pays of for many points, so the current $O(n^2)$ approach is still faster, but in general, this would be the way to go.

### My results

```
Measuring `poly_match_v1`
Took an avg of 223.03ms per iteration (14 iterations)
Measuring `poly_match_v1_5_vectorized`
Took an avg of 41.36ms per iteration (73 iterations)
Measuring `poly_match_v1_6_excessively_vectorized`
Took an avg of 10.04ms per iteration (299 iterations)
Measuring `poly_match_v1_7_numba`
Took an avg of 1.95ms per iteration (500 iterations)
Measuring `poly_match_v1_8_numba_early_exit`
Took an avg of 0.40ms per iteration (500 iterations)
Measuring `poly_match_v2_riir`
Took an avg of 562.50ms per iteration (6 iterations)
Measuring `poly_match_v3_riir_polygon`
Took an avg of 164.46ms per iteration (19 iterations)
Measuring `poly_match_v4_avoid_allocs`
Took an avg of 47.12ms per iteration (64 iterations)
Measuring `poly_match_v5_1_varied_polygons`
Took an avg of 3.19ms per iteration (500 iterations)
Measuring `poly_match_v5_find_all_in_rust`
Took an avg of 3.11ms per iteration (500 iterations)
```

For my own experiments, I tested polygons with different shape and varying number of vertices. I believe that this makes the test more realistic.

I could also update your experiments with the new polygons. It might change the performance numbers slightly.

![polygons](https://github.com/ohadravid/poly-match/assets/18725165/0b452a59-45c3-4c8a-a215-42d872c24de4)